### PR TITLE
fix: Docker hardening — npm ci, non-root user, healthcheck, restart policy

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.env
+database.sqlite
+uploads/
+*.log
+npm-debug.log*

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,18 +3,29 @@ FROM node:20-slim
 
 WORKDIR /app
 
-# Install build dependencies for sqlite3 (native module)
+# Build dependencies for sqlite3 (native module)
 RUN apt-get update && apt-get install -y \
     python3 \
     make \
     g++ \
     && rm -rf /var/lib/apt/lists/*
 
+# Create non-root user
+RUN groupadd -r appgroup && useradd -r -g appgroup appuser
+
+# Install dependencies (reproducible, no lockfile mutation)
 COPY package*.json ./
-RUN npm install
+RUN npm ci --omit=dev
 
 COPY . .
 
+RUN chown -R appuser:appgroup /app
+
+USER appuser
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:5000/api/health', r => r.statusCode === 200 ? process.exit(0) : process.exit(1)).on('error', () => process.exit(1))"
+
 EXPOSE 5000
 
-CMD ["npm", "start"]
+CMD ["node", "server.js"]

--- a/backend/server.js
+++ b/backend/server.js
@@ -75,6 +75,8 @@ app.use(cors({
 
 app.use(express.json());
 
+app.get('/api/health', (req, res) => res.json({ status: 'ok' }));
+
 app.use((req, res, next) => {
     console.log(`${req.method} ${req.url} - Origin: ${req.headers.origin}`);
     next();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,19 @@ services:
       - ./backend/.env
     environment:
       - PORT=5000
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:5000/api/health', r => r.statusCode === 200 ? process.exit(0) : process.exit(1)).on('error', () => process.exit(1))"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
 
   frontend:
     build: ./frontend
     ports:
       - "8081:80"
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
+    restart: unless-stopped

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.log
+npm-debug.log*
+.env

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@ FROM node:20-slim AS build
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Changements

### `backend/Dockerfile`
- `npm install` → `npm ci --omit=dev` : builds reproductibles, pas de mutation du lockfile
- Ajout d'un utilisateur non-root `appuser:appgroup` avec `chown` avant le `USER` switch
- `HEALTHCHECK` via `GET /api/health` (interval 30s, start_period 10s)

### `backend/server.js`
- Ajout de `GET /api/health` (sans auth) utilisé par le healthcheck Docker

### `backend/.dockerignore` (nouveau)
- Exclut `node_modules`, `.env`, `database.sqlite`, `uploads/`, logs

### `frontend/Dockerfile`
- `npm install` → `npm ci`

### `frontend/.dockerignore` (nouveau)
- Exclut `node_modules`, `dist`, `.env`, logs

### `docker-compose.yml`
- `restart: unless-stopped` sur les deux services
- `healthcheck` sur le backend
- `frontend` démarre uniquement quand le backend est `healthy` (`condition: service_healthy`)

## Fichiers modifiés
- `backend/Dockerfile`
- `backend/server.js`
- `backend/.dockerignore` (nouveau)
- `frontend/Dockerfile`
- `frontend/.dockerignore` (nouveau)
- `docker-compose.yml`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)