### PR TITLE
perf: fix N+1 queries on GET /api/bags

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -426,14 +426,24 @@ app.post('/api/change-password', auth, async (req, res) => {
 
 app.get('/api/bags', auth, async (req, res) => {
     try {
-        const result = await query('SELECT * FROM bags ORDER BY created_at DESC');
-        const bags = result.rows;
+        const bagsResult = await query('SELECT * FROM bags ORDER BY created_at DESC');
+        const bags = bagsResult.rows;
 
-        const bagsWithImages = await Promise.all(bags.map(async (bag) => {
-            const imgResult = await query('SELECT * FROM images WHERE bag_id = ?', [bag.id]);
-            return { ...bag, images: imgResult.rows };
-        }));
-        res.json(bagsWithImages);
+        if (bags.length === 0) return res.json([]);
+
+        const placeholders = bags.map(() => '?').join(', ');
+        const imagesResult = await query(
+            `SELECT * FROM images WHERE bag_id IN (${placeholders})`,
+            bags.map(b => b.id)
+        );
+
+        const imagesByBagId = {};
+        for (const img of imagesResult.rows) {
+            if (!imagesByBagId[img.bag_id]) imagesByBagId[img.bag_id] = [];
+            imagesByBagId[img.bag_id].push(img);
+        }
+
+        res.json(bags.map(bag => ({ ...bag, images: imagesByBagId[bag.id] || [] })));
     } catch (err) {
         console.error(err);
         res.status(500).json({ error: 'Internal server error' });


### PR DESCRIPTION
## Problème
`GET /api/bags` faisait **N+1 requêtes** : 1 pour récupérer les bags, puis 1 par bag pour ses images via `Promise.all(bags.map(...))`.

Avec 50 articles en inventaire = 51 requêtes à chaque chargement de page.

## Solution
2 requêtes fixes quelle que soit la taille de l'inventaire :
1. `SELECT * FROM bags ORDER BY created_at DESC`
2. `SELECT * FROM images WHERE bag_id IN (...)`

Puis groupement des images par `bag_id` en mémoire et attachement à chaque bag.

Compatible dual-mode SQLite/PostgreSQL via la couche `query()` existante.

## Fichiers modifiés
- `backend/server.js` (route `GET /api/bags`)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)