### PR TITLE
perf: add missing indexes on FK columns

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -322,6 +322,13 @@ async function setupDb() {
             )
         `);
 
+        await query('CREATE INDEX IF NOT EXISTS idx_images_bag_id ON images(bag_id)');
+        await query('CREATE INDEX IF NOT EXISTS idx_bag_logs_bag_id ON bag_logs(bag_id)');
+        await query('CREATE INDEX IF NOT EXISTS idx_bag_consumables_bag_id ON bag_consumables(bag_id)');
+        await query('CREATE INDEX IF NOT EXISTS idx_bag_consumables_consumable_id ON bag_consumables(consumable_id)');
+        await query('CREATE INDEX IF NOT EXISTS idx_bags_status ON bags(status)');
+        await query('CREATE INDEX IF NOT EXISTS idx_bags_brand ON bags(brand)');
+
         const brandsCount = await query('SELECT COUNT(*) as count FROM brands');
         const count = IS_LOCAL ? brandsCount.rows[0].count : brandsCount.rows[0].count;
         if (parseInt(count) === 0) {


### PR DESCRIPTION
## Problème
Les colonnes de clés étrangères (`bag_id`, `consumable_id`) et les colonnes fréquemment filtrées (`status`, `brand`) n'avaient pas d'index, rendant les JOINs et filtres de plus en plus lents à mesure que l'inventaire grossit.

## Solution
6 indexes ajoutés dans `setupDb()` via `CREATE INDEX IF NOT EXISTS` — idempotent, safe sur une base existante :

| Index | Colonne | Usage |
|-------|---------|-------|
| `idx_images_bag_id` | `images.bag_id` | Fetch images par bag |
| `idx_bag_logs_bag_id` | `bag_logs.bag_id` | Historique par bag |
| `idx_bag_consumables_bag_id` | `bag_consumables.bag_id` | Consommables par bag |
| `idx_bag_consumables_consumable_id` | `bag_consumables.consumable_id` | Lookup consommable |
| `idx_bags_status` | `bags.status` | Filtres dashboard |
| `idx_bags_brand` | `bags.brand` | Filtre marque inventaire |

## Fichiers modifiés
- `backend/server.js` (fonction `setupDb`)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)