### PR TITLE
refactor: centralize STATUSES + fix stale 'sac' labels (#12)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,7 +32,7 @@ function App() {
   const [showModal, setShowModal] = useState(false)
   const [selectedBag, setSelectedBag] = useState(null)
   const [formData, setFormData] = useState({
-    name: '', brand: '', item_type: 'Sac', purchase_price: 0, target_resale_price: 0,
+    name: '', brand: '', item_type: '', purchase_price: 0, target_resale_price: 0,
     actual_resale_price: 0, status: 'to_be_cleaned', fees: 0,
     material_costs: 0, notes: '', purchase_source: '', is_donation: 0, images: []
   })
@@ -58,7 +58,7 @@ function App() {
       setSelectedBag(bag)
       setFormData({
         ...bag,
-        item_type: bag.item_type || 'Sac',
+        item_type: bag.item_type || '',
         images: bag.images || [],
         purchase_price: bag.purchase_price !== undefined ? Number(bag.purchase_price).toFixed(2) : '',
         target_resale_price: bag.target_resale_price !== undefined ? Number(bag.target_resale_price).toFixed(2) : '',
@@ -69,7 +69,7 @@ function App() {
     } else {
       setSelectedBag(null)
       setFormData({
-        name: '', brand: '', item_type: 'Sac', purchase_price: '', target_resale_price: '',
+        name: '', brand: '', item_type: '', purchase_price: '', target_resale_price: '',
         actual_resale_price: '', status: 'to_be_cleaned', fees: '',
         material_costs: '', notes: '', purchase_source: '', is_donation: 0, images: []
       })

--- a/frontend/src/components/BagCard.jsx
+++ b/frontend/src/components/BagCard.jsx
@@ -1,15 +1,6 @@
 import React from 'react'
-import { ImageIcon, Clock, CheckCircle2, TrendingUp } from 'lucide-react'
-
-const STATUSES = {
-  to_be_cleaned: { label: 'À nettoyer', color: '#666', icon: <Clock size={16} /> },
-  cleaning: { label: 'Nettoyage', color: '#3498db', icon: <Clock size={16} /> },
-  repairing: { label: 'Réparation', color: '#e67e22', icon: <Clock size={16} /> },
-  drying: { label: 'Séchage', color: '#1abc9c', icon: <Clock size={16} /> },
-  ready_for_sale: { label: 'Prêt à la vente', color: '#9b59b6', icon: <CheckCircle2 size={16} /> },
-  selling: { label: 'En vente', color: '#f1c40f', icon: <TrendingUp size={16} /> },
-  sold: { label: 'Vendu', color: '#2ecc71', icon: <CheckCircle2 size={16} /> }
-}
+import { ImageIcon } from 'lucide-react'
+import { STATUSES } from '../constants'
 
 function BagCard({ bag, onClick }) {
   const currentStatus = STATUSES[bag.status] || STATUSES.to_be_cleaned

--- a/frontend/src/components/BagModal.jsx
+++ b/frontend/src/components/BagModal.jsx
@@ -1,18 +1,9 @@
 import React, { useState } from 'react'
-import { X, Trash2, Image as ImageIcon, Clock, CheckCircle2, TrendingUp, Plus, Loader2, Camera } from 'lucide-react'
+import { X, Trash2, Image as ImageIcon, Plus, Loader2, Camera } from 'lucide-react'
 import BeforeAfterSlider from './BeforeAfterSlider'
 import BagLog from './BagLog'
 import BagConsumables from './BagConsumables'
-
-const STATUSES = {
-    to_be_cleaned: { label: 'À nettoyer', color: '#666', icon: <Clock size={16} /> },
-    cleaning: { label: 'Nettoyage', color: '#3498db', icon: <Clock size={16} /> },
-    repairing: { label: 'Réparation', color: '#e67e22', icon: <Clock size={16} /> },
-    drying: { label: 'Séchage', color: '#1abc9c', icon: <Clock size={16} /> },
-    ready_for_sale: { label: 'Prêt à la vente', color: '#9b59b6', icon: <CheckCircle2 size={16} /> },
-    selling: { label: 'En vente', color: '#f1c40f', icon: <TrendingUp size={16} /> },
-    sold: { label: 'Vendu', color: '#2ecc71', icon: <CheckCircle2 size={16} /> }
-}
+import { STATUSES } from '../constants'
 
 function BagModal({
     show,
@@ -123,7 +114,7 @@ function BagModal({
                                 list="types-list"
                                 value={formData.item_type || ''}
                                 onChange={e => setFormData({ ...formData, item_type: e.target.value })}
-                                placeholder="ex: Sac"
+                                placeholder="ex: Sac, Chaussures, Vêtement"
                             />
                             <datalist id="types-list">
                                 {itemTypes.map(t => (

--- a/frontend/src/components/DashboardListModal.jsx
+++ b/frontend/src/components/DashboardListModal.jsx
@@ -1,15 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { X, Trash2 } from 'lucide-react'
-
-const STATUSES = {
-    to_be_cleaned: { label: 'À nettoyer' },
-    cleaning: { label: 'Nettoyage' },
-    repairing: { label: 'Réparation' },
-    drying: { label: 'Séchage' },
-    ready_for_sale: { label: 'Prêt à la vente' },
-    selling: { label: 'En vente' },
-    sold: { label: 'Vendu' }
-}
+import { STATUSES } from '../constants'
 
 function DashboardListModal({
     show,

--- a/frontend/src/constants.jsx
+++ b/frontend/src/constants.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Clock, CheckCircle2, TrendingUp } from 'lucide-react'
+
+export const STATUSES = {
+    to_be_cleaned: { label: 'À nettoyer', color: '#666', icon: <Clock size={16} /> },
+    cleaning: { label: 'Nettoyage', color: '#3498db', icon: <Clock size={16} /> },
+    repairing: { label: 'Réparation', color: '#e67e22', icon: <Clock size={16} /> },
+    drying: { label: 'Séchage', color: '#1abc9c', icon: <Clock size={16} /> },
+    ready_for_sale: { label: 'Prêt à la vente', color: '#9b59b6', icon: <CheckCircle2 size={16} /> },
+    selling: { label: 'En vente', color: '#f1c40f', icon: <TrendingUp size={16} /> },
+    sold: { label: 'Vendu', color: '#2ecc71', icon: <CheckCircle2 size={16} /> }
+}

--- a/frontend/src/hooks/useBagActions.js
+++ b/frontend/src/hooks/useBagActions.js
@@ -94,7 +94,7 @@ export const useBagActions = (authenticatedFetch, onSuccess) => {
                             body: JSON.stringify({ url: img.url, type: img.type || 'other', public_id: img.public_id })
                         })
                     ));
-                    toast.success('Nouveau sac ajouté !');
+                    toast.success('Nouvel article ajouté !');
                 } else {
                     toast.success('Modifications enregistrées');
                 }
@@ -110,13 +110,13 @@ export const useBagActions = (authenticatedFetch, onSuccess) => {
     }, [authenticatedFetch, onSuccess]);
 
     const handleDelete = useCallback(async (id, closeModal) => {
-        if (!confirm('Supprimer ce sac ?')) return;
+        if (!confirm('Supprimer cet article ?')) return;
         try {
             const resp = await authenticatedFetch(`/api/bags/${id}`, { method: 'DELETE' });
             if (resp.ok) {
                 onSuccess();
                 closeModal();
-                toast.success('Sac supprimé définitivement');
+                toast.success('Article supprimé définitivement');
             } else {
                 toast.error('Erreur lors de la suppression');
             }


### PR DESCRIPTION
## Summary
- Create `frontend/src/constants.jsx` as single source of truth for `STATUSES` (labels, colors, icons)
- Remove duplicated `STATUSES` constant from `BagCard.jsx`, `BagModal.jsx`, `DashboardListModal.jsx`
- Replace hardcoded French "sac" strings in toasts/confirm dialogs with generic "article"
- Clear default `item_type: 'Sac'` in `App.jsx` form state (now empty string, user fills it in)

## Test plan
- [ ] Ouvrir l'inventaire : les badges de statut s'affichent correctement (couleur + icône)
- [ ] Ouvrir la modal d'édition : le dropdown statut fonctionne, le placeholder Type affiche plusieurs exemples
- [ ] Ajouter un nouvel article : le toast dit "Nouvel article ajouté !" (pas "sac")
- [ ] Supprimer un article : la confirmation dit "Supprimer cet article ?" et le toast "Article supprimé définitivement"
- [ ] Vérifier les listes dashboard : les filtres de statut affichent les bons labels

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)