### PR TITLE
fix: image magic number + orphaned images on bag delete (#13)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -519,7 +519,7 @@ app.put('/api/bags/:id', auth, validateBag, async (req, res) => {
                 fees = ?, material_costs = ?, time_spent = ?, notes = ?,
                 purchase_source = ?, is_donation = ?, item_type = ?
             WHERE id = ?`,
-            [name, brand, purchase_price, target_resale_price, actual_resale_price, status, purchase_date, sale_date, fees, material_costs, time_spent, notes, purchase_source, is_donation ? (IS_LOCAL ? 1 : true) : (IS_LOCAL ? 0 : false), item_type || 'Sac', id]
+            [name, brand, purchase_price, target_resale_price, actual_resale_price, status, purchase_date, sale_date, fees, material_costs, time_spent, notes, purchase_source, is_donation ? (IS_LOCAL ? 1 : true) : (IS_LOCAL ? 0 : false), item_type || '', id]
         );
         res.json({ success: true });
     } catch (err) {
@@ -539,6 +539,8 @@ app.delete('/api/bags/:id', auth, async (req, res) => {
             await deleteImage(img);
         }
 
+        // Explicit delete for PostgreSQL (no ON DELETE CASCADE on images table)
+        await query('DELETE FROM images WHERE bag_id = ?', [id]);
         await query('DELETE FROM bags WHERE id = ?', [id]);
 
         res.json({ success: true });

--- a/frontend/src/hooks/useBagActions.js
+++ b/frontend/src/hooks/useBagActions.js
@@ -37,7 +37,7 @@ export const useBagActions = (authenticatedFetch, onSuccess) => {
                 } else {
                     setFormData(prev => ({
                         ...prev,
-                        images: Array.isArray(prev.images) ? [...prev.images, { url: data.url, type: type || 'other', id: Date.now(), public_id: data.public_id }] : [{ url: data.url, type: type || 'other', id: Date.now(), public_id: data.public_id }]
+                        images: Array.isArray(prev.images) ? [...prev.images, { url: data.url, type: type || 'other', _pending: true, public_id: data.public_id }] : [{ url: data.url, type: type || 'other', _pending: true, public_id: data.public_id }]
                     }));
                     toast.success('Image importée', { id: loadingToast });
                 }
@@ -51,7 +51,7 @@ export const useBagActions = (authenticatedFetch, onSuccess) => {
     }, [authenticatedFetch, onSuccess]);
 
     const handleImageDelete = useCallback(async (img, setFormData) => {
-        if (img.id && img.id < 1000000000) {
+        if (img.id && !img._pending) {
             try {
                 await authenticatedFetch(`/api/images/${img.id}`, { method: 'DELETE' });
                 setFormData(prev => ({


### PR DESCRIPTION
## Summary
- Replace magic number `1000000000` check with explicit `_pending: true` flag on unsaved images
- Pending images (uploaded before bag creation) now use `_pending: true` instead of `id: Date.now()` as a sentinel value
- Add explicit `DELETE FROM images WHERE bag_id = ?` before deleting a bag to prevent orphaned image records in PostgreSQL (SQLite uses ON DELETE CASCADE, PostgreSQL doesn't yet)
- Remove hardcoded `item_type || 'Sac'` fallback in PUT /api/bags backend

## Test plan
- [ ] Créer un nouvel article, ajouter des images avant de sauvegarder : les images peuvent être retirées de la liste
- [ ] Supprimer une image d'un article existant : la suppression API est bien appelée
- [ ] Supprimer un article : vérifier que les images sont bien supprimées de Cloudinary et de la DB
- [ ] En mode PostgreSQL : vérifier l'absence d'enregistrements orphelins dans la table `images` après suppression d'un article

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)