### PR TITLE
ux: add missing error/success toasts (#14)

### DIFF
--- a/frontend/src/components/BusinessTab.jsx
+++ b/frontend/src/components/BusinessTab.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Plus, Trash2, Download, Calculator, TrendingUp, TrendingDown } from 'lucide-react'
+import { toast } from 'react-hot-toast'
 import StatCard from './StatCard'
 
 function BusinessTab({ expenses, bags, fetchExpenses, authenticatedFetch }) {
@@ -23,32 +24,53 @@ function BusinessTab({ expenses, bags, fetchExpenses, authenticatedFetch }) {
                 setShowModal(false)
                 fetchExpenses()
                 setFormData({ description: '', amount: 0, category: 'other', date: new Date().toISOString().split('T')[0] })
+                toast.success('Dépense ajoutée')
+            } else {
+                toast.error('Erreur lors de l\'enregistrement')
             }
         } catch (err) {
             console.error('Failed to save expense', err)
+            toast.error('Échec de la communication avec le serveur')
         }
     }
 
     const handleDelete = async (id) => {
         if (!confirm('Supprimer cette dépense ?')) return
         try {
-            await authenticatedFetch(`/api/expenses/${id}`, { method: 'DELETE' })
-            fetchExpenses()
+            const resp = await authenticatedFetch(`/api/expenses/${id}`, { method: 'DELETE' })
+            if (resp.ok) {
+                fetchExpenses()
+                toast.success('Dépense supprimée')
+            } else {
+                toast.error('Erreur lors de la suppression')
+            }
         } catch (err) {
             console.error('Failed to delete expense', err)
+            toast.error('Échec de la suppression')
         }
     }
 
     const exportCSV = async () => {
-        const resp = await authenticatedFetch('/api/export/csv')
-        const blob = await resp.blob()
-        const url = window.URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = url
-        a.download = 'tableau_de_bord_atelier.csv'
-        document.body.appendChild(a)
-        a.click()
-        a.remove()
+        const loadingToast = toast.loading('Export en cours...')
+        try {
+            const resp = await authenticatedFetch('/api/export/csv')
+            if (!resp.ok) {
+                toast.error('Erreur lors de l\'export', { id: loadingToast })
+                return
+            }
+            const blob = await resp.blob()
+            const url = window.URL.createObjectURL(blob)
+            const a = document.createElement('a')
+            a.href = url
+            a.download = 'tableau_de_bord_atelier.csv'
+            document.body.appendChild(a)
+            a.click()
+            a.remove()
+            toast.success('Export téléchargé', { id: loadingToast })
+        } catch (err) {
+            console.error('Failed to export CSV', err)
+            toast.error('Échec de l\'export', { id: loadingToast })
+        }
     }
 
     // Calculations

--- a/frontend/src/components/ConsumablesTab.jsx
+++ b/frontend/src/components/ConsumablesTab.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { Plus, Trash2, Edit2, Package } from 'lucide-react'
+import { toast } from 'react-hot-toast'
 
 function ConsumablesTab({ consumables, fetchConsumables, authenticatedFetch }) {
     const [showModal, setShowModal] = useState(false)
@@ -47,19 +48,29 @@ function ConsumablesTab({ consumables, fetchConsumables, authenticatedFetch }) {
             if (resp.ok) {
                 setShowModal(false)
                 fetchConsumables()
+                toast.success(selectedItem ? 'Produit mis à jour' : 'Produit ajouté')
+            } else {
+                toast.error('Erreur lors de l\'enregistrement')
             }
         } catch (err) {
             console.error('Failed to save consumable', err)
+            toast.error('Échec de la communication avec le serveur')
         }
     }
 
     const handleDelete = async (id) => {
         if (!confirm('Supprimer ce produit ?')) return
         try {
-            await authenticatedFetch(`/api/consumables/${id}`, { method: 'DELETE' })
-            fetchConsumables()
+            const resp = await authenticatedFetch(`/api/consumables/${id}`, { method: 'DELETE' })
+            if (resp.ok) {
+                fetchConsumables()
+                toast.success('Produit supprimé')
+            } else {
+                toast.error('Erreur lors de la suppression')
+            }
         } catch (err) {
             console.error('Failed to delete consumable', err)
+            toast.error('Échec de la suppression')
         }
     }
 

--- a/frontend/src/hooks/useBrandActions.js
+++ b/frontend/src/hooks/useBrandActions.js
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { toast } from 'react-hot-toast';
 
 export const useBrandActions = (authenticatedFetch, onSuccess) => {
     const handleAddBrand = useCallback(async (brandName) => {
@@ -12,8 +13,10 @@ export const useBrandActions = (authenticatedFetch, onSuccess) => {
                 onSuccess();
                 return true;
             }
+            toast.error('Erreur lors de l\'ajout de la marque');
         } catch (err) {
             console.error('Failed to add brand', err);
+            toast.error('Échec de l\'ajout de la marque');
         }
         return false;
     }, [authenticatedFetch, onSuccess]);

--- a/frontend/src/hooks/useItemTypeActions.js
+++ b/frontend/src/hooks/useItemTypeActions.js
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { toast } from 'react-hot-toast';
 
 export const useItemTypeActions = (authenticatedFetch, onSuccess) => {
     const handleAddItemType = useCallback(async (name) => {
@@ -12,8 +13,10 @@ export const useItemTypeActions = (authenticatedFetch, onSuccess) => {
                 onSuccess();
                 return true;
             }
+            toast.error('Erreur lors de l\'ajout du type');
         } catch (err) {
             console.error('Failed to add item type', err);
+            toast.error('Échec de l\'ajout du type');
         }
         return false;
     }, [authenticatedFetch, onSuccess]);


### PR DESCRIPTION
## Summary
- **BusinessTab**: import `react-hot-toast`, add success/error toasts on expense creation, deletion, and CSV export (also wraps export in try/catch — was previously unhandled)
- **ConsumablesTab**: import `react-hot-toast`, add success/error toasts on consumable creation/update and deletion
- **useBrandActions**: add error toast when brand creation fails (was silent)
- **useItemTypeActions**: add error toast when item type creation fails (was silent)

## Test plan
- [ ] Ajouter une dépense dans l'onglet Business → toast "Dépense ajoutée"
- [ ] Supprimer une dépense → toast "Dépense supprimée"
- [ ] Exporter CSV → toast de chargement puis "Export téléchargé"
- [ ] Ajouter un consommable → toast "Produit ajouté"
- [ ] Modifier un consommable → toast "Produit mis à jour"
- [ ] Supprimer un consommable → toast "Produit supprimé"
- [ ] Simuler une erreur réseau → toast d'erreur s'affiche (pas d'échec silencieux)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)